### PR TITLE
Automatically calculate number of peers

### DIFF
--- a/test/onyx_starter/jobs/sample_job_test.clj
+++ b/test/onyx_starter/jobs/sample_job_test.clj
@@ -17,15 +17,11 @@
   (let [distinct-workflows (count-distinct-tasks workflows/workflow)
         dev-env            (component/start (onyx-dev-env distinct-workflows))]
     (try
-      (let [{:keys [loud-output question-output period-output]} (submit-sample/submit-job dev-env)]
+      (let [{:keys [loud-output question-output]} (submit-sample/submit-job dev-env)]
         (clojure.pprint/pprint loud-output)
         (println)
         (clojure.pprint/pprint question-output)
-        (println)
-        (clojure.pprint/pprint period-output)
         (is (= 11 (count question-output)))
-        (is (= 11 (count loud-output)))
-        (is (= 11 (count period-output)))
-        )
+        (is (= 11 (count loud-output))))
       (finally
         (component/stop dev-env)))))

--- a/test/onyx_starter/jobs/sample_job_test.clj
+++ b/test/onyx_starter/jobs/sample_job_test.clj
@@ -2,19 +2,30 @@
   (:require [clojure.test :refer [deftest is]]
             [com.stuartsierra.component :as component]
             [onyx-starter.launcher.submit-sample-job :as submit-sample]
+            [onyx-starter.workflows.sample-workflow :as workflows]
             [onyx-starter.launcher.dev-system :refer [onyx-dev-env]]
             [onyx-starter.functions.sample-functions]
             [onyx.api]))
 
+(defn count-distinct-tasks [workflow]
+  (->> workflow
+       flatten
+       set
+       count))
+
 (deftest test-sample-dev-job
-  ;; 7 peers for 7 distinct tasks in the workflow
-  (let [dev-env (component/start (onyx-dev-env 7))]
-    (try 
-      (let [{:keys [loud-output question-output]} (submit-sample/submit-job dev-env)]
+  (let [distinct-workflows (count-distinct-tasks workflows/workflow)
+        dev-env            (component/start (onyx-dev-env distinct-workflows))]
+    (try
+      (let [{:keys [loud-output question-output period-output]} (submit-sample/submit-job dev-env)]
         (clojure.pprint/pprint loud-output)
         (println)
         (clojure.pprint/pprint question-output)
+        (println)
+        (clojure.pprint/pprint period-output)
         (is (= 11 (count question-output)))
-        (is (= 11 (count loud-output))))
-      (finally 
+        (is (= 11 (count loud-output)))
+        (is (= 11 (count period-output)))
+        )
+      (finally
         (component/stop dev-env)))))


### PR DESCRIPTION
Added the count-distinct-tasks function that calculates the number of peers based on the number of distinct tasks in the workflow.